### PR TITLE
Added async plugin support

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -129,14 +129,14 @@ exports.remove = function(fn){
   if (this.isNew()) return fn(new Error('not saved'));
   var self = this;
   var url = this.url();
-  this.model.emit('removing', this);
-  this.emit('removing');
-  request.del(url, function(res){
-    if (res.error) return fn(error(res));
-    self.removed = true;
-    self.model.emit('remove', self);
-    self.emit('remove');
-    fn();
+  this.run('removing', function() {
+    request.del(url, function(res){
+      if (res.error) return fn(error(res));
+      self.removed = true;
+      self.model.emit('remove', self);
+      self.emit('remove');
+      fn();
+    });
   });
 };
 
@@ -158,15 +158,15 @@ exports.save = function(fn){
   var url = this.model.url();
   fn = fn || noop;
   if (!this.isValid()) return fn(new Error('validation failed'));
-  this.model.emit('saving', this);
-  this.emit('saving');
-  request.post(url, self, function(res){
-    if (res.error) return fn(error(res));
-    if (res.body) self.primary(res.body.id);
-    self.dirty = {};
-    self.model.emit('save', self);
-    self.emit('save');
-    fn();
+  this.run('saving', function() {
+    request.post(url, self, function(res){
+      if (res.error) return fn(error(res));
+      if (res.body) self.primary(res.body.id);
+      self.dirty = {};
+      self.model.emit('save', self);
+      self.emit('save');
+      fn();
+    });
   });
 };
 
@@ -182,14 +182,14 @@ exports.update = function(fn){
   var url = this.url();
   fn = fn || noop;
   if (!this.isValid()) return fn(new Error('validation failed'));
-  this.model.emit('saving', this);
-  this.emit('saving');
-  request.put(url, self, function(res){
-    if (res.error) return fn(error(res));
-    self.dirty = {};
-    self.model.emit('save', self);
-    self.emit('save');
-    fn();
+  this.run('saving', function() {
+    request.put(url, self, function(res){
+      if (res.error) return fn(error(res));
+      self.dirty = {};
+      self.model.emit('save', self);
+      self.emit('save');
+      fn();
+    });
   });
 };
 
@@ -276,3 +276,34 @@ exports.toJSON = function(){
 function error(res) {
   return new Error('got ' + res.status + ' response');
 }
+
+/**
+ * Run functions beforehand
+ *
+ * @param {String} event
+ * @param {Function} fn
+ * @api private
+ */
+
+exports.run = function(event, done) {
+  var fns = this.model.listeners(event).concat(this.listeners(event)),
+      pending = 0;
+
+  function next() {
+    if(!--pending) return done();
+  }
+
+  for (var i = 0, len = fns.length; i < len; i++) {
+    var fn = fns[i];
+    if (fn.length > 1) {
+      pending++;
+      fn(this, next);
+    } else {
+      fn(this);
+    }
+  }
+
+  if(!pending) return done();
+};
+
+

--- a/test/model.js
+++ b/test/model.js
@@ -167,7 +167,9 @@ describe('Model#remove()', function(){
       var pet = new Pet({ name: 'Tobi' });
       pet.save(function(err){
         assert(!err);
-        pet.on('removing', done);
+        pet.on('removing', function() {
+          done();
+        });
         pet.remove();
       });
     })
@@ -231,6 +233,20 @@ describe('Model#save(fn)', function(){
         });
         pet.save();
       })
+
+      it('should handle async plugins', function(done){
+        var pet = new Pet({ name: 'Tobi', species: 'Ferret' });
+        pet.on('saving', function(pet, next) {
+          setTimeout(function() {
+            next();
+          }, 100);
+        });
+        Pet.once('save', function(obj){
+          assert(pet == obj);
+          done();
+        });
+        pet.save();
+      })
     })
 
     describe('and invalid', function(){
@@ -270,7 +286,9 @@ describe('Model#save(fn)', function(){
         var pet = new Pet({ name: 'Tobi', species: 'Ferret' });
         pet.save(function(err){
           assert(!err);
-          pet.on('saving', done);
+          pet.on('saving', function() {
+            done();
+          });
           pet.save();
         });
       })


### PR DESCRIPTION
This pull request adds asynchronous plugin support to the `saving` and `removing` events. I found this useful on the server-side, but I'm sure some people will find it useful on the client-side. 

The implementation inspects the function's length (like Mocha) to determine if it's an async plugin or not. 

``` js
var pwd = require('pwd');

User.use(hash);

/**
 * Hashing Function
 */ 

function hash(User) {
  User.attr('salt')
  User.on('saving', function(user, done) {
    if(!user.isNew()) return done();
    pwd.hash(user.password(), function(err, hash) {
      user.salt(hash);
      done();
    });
  });
}
```

Definitely open to suggestions, modifications, or ideas.
