### PR TITLE
added destroy as an alias

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -124,6 +124,7 @@ exports.validate = function(){
  * @api public
  */
 
+exports.destroy =
 exports.remove = function(fn){
   fn = fn || noop;
   if (this.isNew()) return fn(new Error('not saved'));

--- a/test/model.js
+++ b/test/model.js
@@ -186,6 +186,12 @@ describe('Model#remove()', function(){
   })
 })
 
+describe('Model#destroy()', function(){
+  it('should be an alias for remove', function(){
+    assert(Pet.prototype.remove === Pet.prototype.destroy);
+  })
+})
+
 describe('Model#save(fn)', function(){
   beforeEach(reset);
 


### PR DESCRIPTION
I prefer `destroy` as it mirrors what Backbone calls it, and just feels more right than `remove`. I feel like having an alias is pretty low cost, and it's not going to ever be used for anything else since it would be too ambiguous.
