### PR TITLE
changed #toJSON to return a copy

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,7 +115,7 @@ post.on('change title', function(val, prev){
 
 ### .toJSON()
 
-  Return a JSON representation of the model (its attributes).
+  Return a cloned JSON representation of the model (its attributes).
 
 ### .has(attr)
 

--- a/component.json
+++ b/component.json
@@ -11,6 +11,7 @@
     "database"
   ],
   "dependencies": {
+    "component/clone": "*",
     "component/each": "*",
     "component/json": "*",
     "component/emitter": "*",

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -6,6 +6,7 @@
 var Emitter = require('emitter')
   , request = require('superagent')
   , JSON = require('json')
+  , clone = require('clone')
   , each = require('each')
   , noop = function(){};
 
@@ -263,7 +264,7 @@ exports.has = function(attr){
  */
 
 exports.toJSON = function(){
-  return this.attrs;
+  return clone(this.attrs);
 };
 
 /**

--- a/test/model.js
+++ b/test/model.js
@@ -344,9 +344,10 @@ describe('Model#url(path)', function(){
 })
 
 describe('Model#toJSON()', function(){
-  it('should return the attributes', function(){
+  it('should return a copy of the attributes', function(){
     var user = new User({ name: 'Tobi', age: 2 });
     var obj = user.toJSON();
+    assert(obj !== user.attrs);
     assert('Tobi' == obj.name);
     assert(2 == obj.age);
   })


### PR DESCRIPTION
`toJSON` is often used before passing the attrs to another party, and you don't want them accidentally editing them out from under your models
