### PR TITLE
use id or _id as primary key in save callback

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -158,6 +158,7 @@ exports.save = function(fn){
   if (!this.isNew()) return this.update(fn);
   var self = this;
   var url = this.model.url();
+  var primaryKey = this.model.primaryKey;
   fn = fn || noop;
   if (!this.isValid()) return fn(new Error('validation failed'));
   this.model.emit('saving', this);
@@ -168,7 +169,7 @@ exports.save = function(fn){
     .send(self)
     .end(function(res){
       if (res.error) return fn(error(res), res);
-      if (res.body) self.primary(res.body.id);
+      if (res.body) self.primary(res.body[primaryKey]);
       self.dirty = {};
       self.model.emit('save', self, res);
       self.emit('save');


### PR DESCRIPTION
If your using model and _id as primary key, a new model will be new even after calling save.
