### PR TITLE
added Model.primary(name) to set the key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ components:
 clean:
 	rm -fr build components template.js
 
-test:
+test: build
 	@node test/server
 
 .PHONY: clean test

--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,20 @@ var Post = model('Post')
   .attr('updated_at', { type: 'date' })
 ```
 
+### .primary(name)
+  
+  Set the primary attribute key's `name`.
+
+```js
+var model = require('model');
+
+var Post = model('Post')
+  .attr('slug')
+  .attr('title')
+  .attr('body')
+  .primary('slug');
+```
+
 ### .validate(fn)
 
   TODO: validation callback docs

--- a/lib/static.js
+++ b/lib/static.js
@@ -33,7 +33,7 @@ exports.url = function(path){
  *
  *   User.headers({
  *    'X-CSRF-Token': 'some token',
- *    'X-API-Token': 'api token 
+ *    'X-API-Token': 'api token
  *   });
  *
  * @param {String|Object} header(s)
@@ -88,9 +88,8 @@ exports.attr = function(name, options){
   this.attrs[name] = options || {};
 
   // implied pk
-  if ('_id' == name || 'id' == name) {
-    this.attrs[name].primaryKey = true;
-    this.primaryKey = name;
+  if (!this.primaryKey && ('_id' == name || 'id' == name)) {
+    this.primary(name);
   }
 
   // getter / setter method
@@ -106,6 +105,19 @@ exports.attr = function(name, options){
     return this;
   };
 
+  return this;
+};
+
+/**
+ * Set the primary attribute `name` for the model.
+ *
+ * @param {String} name
+ * @return {Function} self
+ * @api public
+ */
+
+exports.primary = function(name){
+  this.primaryKey = name;
   return this;
 };
 

--- a/test/statics.js
+++ b/test/statics.js
@@ -20,6 +20,13 @@ describe('Model.url(string)', function(){
   })
 })
 
+describe('Model.primary(name)', function(){
+  it('should set the model primary key', function(){
+    User.primary('id');
+    assert('id' == User.primaryKey);
+  })
+})
+
 describe('Model.attrs', function(){
   it('should hold the defined attrs', function(){
     assert('string' == User.attrs.name.type);


### PR DESCRIPTION
I've been wanting to have a nicer way to set the `primary` key for a model. Instead of having to break the nice chainable API to do:

``` js
var Model = model('post')
  .attr('id')
  .attr('slug')
  .attr('title')
  .attr('body');

Model.primaryKey = 'slug';
```

Instead, we can add a chainable method to set the `primaryKey`. Note that I removed the `model[attr].primaryKey = true` piece of code because it seemed unnecessary and wasn't being used anywhere, so I figured it was a bit of feature creep for now.

Now setting a `primaryKey` would look like:

``` js
var Model = model('post')
  .attr('id')
  .attr('slug')
  .attr('title')
  .attr('body')
  .primary('slug');
```

But then I realized that there might even be a better way using the extra `options` we can tie to a specific property, which would look like this:

``` js
var Model = model('post')
  .attr('id')
  .attr('slug', { primary: true })
  .attr('title')
  .attr('body');
```

That last option seems the cleanest to me, and it builds on the existing API. (Note: that's **not** what's in the PR, so let me know if you like that one better and I'll submit another with it.)
