### PR TITLE
Expose request object for configuration of superagent

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -15,6 +15,11 @@ var noop = function(){};
 Emitter(exports);
 
 /**
+ * Expose request for configuration
+ */
+exports.request = request;
+
+/**
  * Register an error `msg` on `attr`.
  *
  * @param {String} attr
@@ -130,7 +135,7 @@ exports.destroy = function(fn){
   var url = this.url();
   this.model.emit('destroying', this);
   this.emit('destroying');
-  request
+  this.request
     .del(url)
     .set(this.model._headers)
     .end(function(res){
@@ -163,7 +168,7 @@ exports.save = function(fn){
   if (!this.isValid()) return fn(new Error('validation failed'));
   this.model.emit('saving', this);
   this.emit('saving');
-  request
+  this.request
     .post(url)
     .set(this.model._headers)
     .send(self)
@@ -191,7 +196,7 @@ exports.update = function(fn){
   if (!this.isValid()) return fn(new Error('validation failed'));
   this.model.emit('saving', this);
   this.emit('saving');
-  request
+  this.request
     .put(url)
     .set(this.model._headers)
     .send(self)

--- a/lib/static.js
+++ b/lib/static.js
@@ -6,6 +6,13 @@ var request = require('superagent');
 var Collection = require('collection');
 var noop = function(){};
 
+
+/**
+ * Expose request for configuration
+ */
+exports.request = request;
+
+
 /**
  * Construct a url to the given `path`.
  *
@@ -137,7 +144,7 @@ exports.destroyAll = function(fn){
   fn = fn || noop;
   var self = this;
   var url = this.url('');
-  request
+  this.request
     .del(url)
     .set(this._headers)
     .end(function(res){
@@ -156,7 +163,7 @@ exports.destroyAll = function(fn){
 exports.all = function(fn){
   var self = this;
   var url = this.url('');
-  request
+  this.request
     .get(url)
     .set(this._headers)
     .end(function(res){
@@ -180,7 +187,7 @@ exports.all = function(fn){
 exports.get = function(id, fn){
   var self = this;
   var url = this.url(id);
-  request
+  this.request
     .get(url)
     .set(this._headers)
     .end(function(res){


### PR DESCRIPTION
Makes the superagent handles extendible via plugins.
I use this for forcing
`superagent.Request.prototype._withCredentials = true`
in order to make the models work cross origin.
