### PR TITLE
fix toJSON() copy

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -284,7 +284,7 @@ exports.has = function(attr){
  */
 
 exports.toJSON = function(){
-  return this.attrs;
+  return JSON.parse(JSON.stringify(this.attrs));
 };
 
 /**

--- a/test/model.js
+++ b/test/model.js
@@ -402,6 +402,11 @@ describe('Model#toJSON()', function(){
     assert('Tobi' == obj.name);
     assert(2 == obj.age);
   })
+  it('should copy', function(){
+    var user = new User({ name: 'Tobi', age: 2 });
+    user.toJSON().name = 'Loki';
+    assert('Tobi' == user.toJSON().name);
+  })
 })
 
 describe('Model#isValid()', function(){


### PR DESCRIPTION
I expect `.toJSON()` to return a copy, so I can mess with data without changing the real model.

We might use a more efficient cloning algorithm, I'm not sure where this method is used.
