### PR TITLE
Implementation opt-in error handling #8?

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -207,6 +207,25 @@ user.save(function(err){
   Destroy and invoke optional `fn(err)`.
 
   Emits "destroy" when successfully deleted.
+  
+### .onError(fn)
+
+  Register a custom error handler for the model class and/or model instances.
+  If called on the Model class, the error handler is used for static methods as well as the methods of the model
+  instances. If called on a model instance, the error handler is only used for methods of this instance.
+  
+```js
+var handler1 = function(err, res) {...};
+var handler2 = function(err, res) {...};
+
+var Car = model('Car')
+  .onError(handler1);
+  
+var car1 = new Car(); // uses handler1
+
+var car2 = new Car();
+car2.onError(handler2); // uses handler2
+```
 
 ## Links
 

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -181,7 +181,7 @@ exports.save = function(fn){
     .send(self)
     .end(function(err, res){
       if (err || res.error)
-        return fn(error(err,res), res);
+        return fn(self.error(err,res), res);
 
       if (res.body) self.primary(res.body[key]);
       self.dirty = {};
@@ -299,8 +299,3 @@ exports.toJSON = function(){
  * @api private
  */
 
-function error(err, res) {
-  if (err) return err;
-  else return new Error('got ' + res.status + ' response');
-}
-exports.error = error;

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -146,7 +146,7 @@ exports.destroy = function(fn){
     .set(this.model._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._onError(err,res), res);
+        return fn(self._toError(err,res), res);
       self.destroyed = true;
       self.model.emit('destroy', self, res);
       self.emit('destroy');
@@ -181,7 +181,7 @@ exports.save = function(fn){
     .send(self)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._onError(err,res), res);
+        return fn(self._toError(err,res), res);
 
       if (res.body) self.primary(res.body[key]);
       self.dirty = {};
@@ -211,7 +211,7 @@ exports.update = function(fn){
     .send(self)
     .end(function(err,res){
       if (err || res.error) 
-          return fn(self._onError(err, res), res);
+          return fn(self._toError(err, res), res);
       self.dirty = {};
       self.model.emit('save', self, res);
       self.emit('save');
@@ -299,9 +299,9 @@ exports.toJSON = function(){
  * @api public
  */
 
-exports.onError = function(fn) {
+exports.toError = function(fn) {
     if (fn) {
-        this._onError = fn;
+        this._toError = fn;
     }
 
     return this;
@@ -316,7 +316,7 @@ exports.onError = function(fn) {
  * @api private
  */
 
-exports._onError = function(err, res) {
+exports._toError = function(err, res) {
   if (err) return err;
   else return new Error('got ' + res.status + ' response');
 }

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -300,7 +300,7 @@ exports.toJSON = function(){
  */
 
 function error(err, res) {
-  if (err) return err
+  if (err) return err;
   else return new Error('got ' + res.status + ' response');
 }
-exports.error = error
+exports.error = error;

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -181,7 +181,7 @@ exports.save = function(fn){
     .send(self)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self.error(err,res), res);
+        return fn(error(err,res), res);
 
       if (res.body) self.primary(res.body[key]);
       self.dirty = {};
@@ -299,3 +299,8 @@ exports.toJSON = function(){
  * @api private
  */
 
+function error(err, res) {
+  if (err) return err;
+  else return new Error('got ' + res.status + ' response');
+}
+exports.error = error;

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -26,6 +26,23 @@ Emitter(exports);
 exports.request = request;
 
 /**
+ * Register an error `msg` on `attr`.
+ *
+ * @param {String} attr
+ * @param {String} msg
+ * @return {Object} self
+ * @api public
+ */
+
+exports.error = function(attr, msg){
+  this.errors.push({
+    attr: attr,
+    message: msg
+  });
+  return this;
+};
+
+/**
  * Check if this model is new.
  *
  * @return {Boolean}
@@ -129,7 +146,7 @@ exports.destroy = function(fn){
     .set(this.model._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._error(err,res), res);
+        return fn(self._onError(err,res), res);
       self.destroyed = true;
       self.model.emit('destroy', self, res);
       self.emit('destroy');
@@ -164,7 +181,7 @@ exports.save = function(fn){
     .send(self)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._error(err,res), res);
+        return fn(self._onError(err,res), res);
 
       if (res.body) self.primary(res.body[key]);
       self.dirty = {};
@@ -194,7 +211,7 @@ exports.update = function(fn){
     .send(self)
     .end(function(err,res){
       if (err || res.error) 
-          return fn(self._error(err, res), res);
+          return fn(self._onError(err, res), res);
       self.dirty = {};
       self.model.emit('save', self, res);
       self.emit('save');
@@ -275,20 +292,31 @@ exports.toJSON = function(){
 };
 
 /**
- * Response error helper.
+ * Register a custom error handler for the model instance.
  *
- * @param {Response} er
+ * @param {Function} fn
+ * @return {Object} self
+ * @api public
+ */
+
+exports.onError = function(fn) {
+    if (fn) {
+        this._onError = fn;
+    }
+
+    return this;
+}
+
+/**
+ * Standard error handler.
+ *
+ * @param {Error} err
+ * @param {Response} res
  * @return {Error}
  * @api private
  */
 
-exports.error = function(fn) {
-    if (fn) {
-        this._error = fn;
-    }
-}
-
-exports._error = function(err, res) {
+exports._onError = function(err, res) {
   if (err) return err;
   else return new Error('got ' + res.status + ' response');
 }

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -144,7 +144,8 @@ exports.destroy = function(fn){
   this.request
     .del(url)
     .set(this.model._headers)
-    .end(function(res){
+    .end(function(err, res){
+      if (err) return fn(err, null);
       if (res.error) return fn(error(res), res);
       self.destroyed = true;
       self.model.emit('destroy', self, res);
@@ -178,7 +179,8 @@ exports.save = function(fn){
     .post(url)
     .set(this.model._headers)
     .send(self)
-    .end(function(res){
+    .end(function(err, res){
+      if (err) return fn(err, null);
       if (res.error) return fn(error(res), res);
       if (res.body) self.primary(res.body[key]);
       self.dirty = {};
@@ -206,7 +208,8 @@ exports.update = function(fn){
     .put(url)
     .set(this.model._headers)
     .send(self)
-    .end(function(res){
+    .end(function(err, res){
+      if (err) return fn(err, null);
       if (res.error) return fn(error(res), res);
       self.dirty = {};
       self.model.emit('save', self, res);

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -26,23 +26,6 @@ Emitter(exports);
 exports.request = request;
 
 /**
- * Register an error `msg` on `attr`.
- *
- * @param {String} attr
- * @param {String} msg
- * @return {Object} self
- * @api public
- */
-
-exports.error = function(attr, msg){
-  this.errors.push({
-    attr: attr,
-    message: msg
-  });
-  return this;
-};
-
-/**
  * Check if this model is new.
  *
  * @return {Boolean}
@@ -146,7 +129,7 @@ exports.destroy = function(fn){
     .set(this.model._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(error(err,res), res);
+        return fn(self._error(err,res), res);
       self.destroyed = true;
       self.model.emit('destroy', self, res);
       self.emit('destroy');
@@ -181,7 +164,7 @@ exports.save = function(fn){
     .send(self)
     .end(function(err, res){
       if (err || res.error)
-        return fn(error(err,res), res);
+        return fn(self._error(err,res), res);
 
       if (res.body) self.primary(res.body[key]);
       self.dirty = {};
@@ -211,7 +194,7 @@ exports.update = function(fn){
     .send(self)
     .end(function(err,res){
       if (err || res.error) 
-          return fn(error(err, res), res);
+          return fn(self._error(err, res), res);
       self.dirty = {};
       self.model.emit('save', self, res);
       self.emit('save');
@@ -299,8 +282,13 @@ exports.toJSON = function(){
  * @api private
  */
 
-function error(err, res) {
+exports.error = function(fn) {
+    if (fn) {
+        this._error = fn;
+    }
+}
+
+exports._error = function(err, res) {
   if (err) return err;
   else return new Error('got ' + res.status + ' response');
 }
-exports.error = error;

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -145,8 +145,8 @@ exports.destroy = function(fn){
     .del(url)
     .set(this.model._headers)
     .end(function(err, res){
-      if (err) return fn(err, null);
-      if (res.error) return fn(error(res), res);
+      if (err || res.error)
+        return fn(error(err,res), res);
       self.destroyed = true;
       self.model.emit('destroy', self, res);
       self.emit('destroy');
@@ -180,8 +180,9 @@ exports.save = function(fn){
     .set(this.model._headers)
     .send(self)
     .end(function(err, res){
-      if (err) return fn(err, null);
-      if (res.error) return fn(error(res), res);
+      if (err || res.error)
+        return fn(error(err,res), res);
+
       if (res.body) self.primary(res.body[key]);
       self.dirty = {};
       self.model.emit('save', self, res);
@@ -208,9 +209,9 @@ exports.update = function(fn){
     .put(url)
     .set(this.model._headers)
     .send(self)
-    .end(function(err, res){
-      if (err) return fn(err, null);
-      if (res.error) return fn(error(res), res);
+    .end(function(err,res){
+      if (err || res.error) 
+          return fn(error(err, res), res);
       self.dirty = {};
       self.model.emit('save', self, res);
       self.emit('save');
@@ -298,6 +299,8 @@ exports.toJSON = function(){
  * @api private
  */
 
-function error(res) {
-  return new Error('got ' + res.status + ' response');
+function error(err, res) {
+  if (err) return err
+  else return new Error('got ' + res.status + ' response');
 }
+exports.error = error

--- a/lib/static.js
+++ b/lib/static.js
@@ -212,4 +212,4 @@ function error(err, res) {
   else return new Error('got ' + res.status + ' response');
 }
 
-export.error = error
+exports.error = error

--- a/lib/static.js
+++ b/lib/static.js
@@ -2,6 +2,13 @@
  * Module dependencies.
  */
 
+try {
+  var Emitter = require('emitter');
+  var each = require('each');
+} catch (e) {
+  var Emitter = require('component-emitter');
+  var each = require('component-each');
+}
 var Collection = require('collection');
 var request = require('superagent');
 var noop = function(){};

--- a/lib/static.js
+++ b/lib/static.js
@@ -148,7 +148,7 @@ exports.destroyAll = function(fn){
     .set(this._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._onError(err,res), null, res);
+        return fn(self._toError(err,res), null, res);
       fn(null, [], res);
     });
 };
@@ -168,7 +168,7 @@ exports.all = function(fn){
     .set(this._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._onError(err,res), null, res);
+        return fn(self._toError(err,res), null, res);
       var col = new Collection;
       for (var i = 0, len = res.body.length; i < len; ++i) {
         col.push(new self(res.body[i]));
@@ -193,7 +193,7 @@ exports.get = function(id, fn){
     .set(this._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._onError(err,res), null, res);
+        return fn(self._toError(err,res), null, res);
       var model = new self(res.body);
       fn(null, model, res);
     });
@@ -206,9 +206,9 @@ exports.get = function(id, fn){
  * @return {Object} self
  * @api public
  */
-exports.onError = function(fn) {
+exports.toError = function(fn) {
     if (fn) {
-        this._onError = this.prototype._onError = fn;
+        this._toError = this.prototype._toError = fn;
     }
 
     return this;
@@ -222,7 +222,7 @@ exports.onError = function(fn) {
  * @return {Error}
  * @api private
  */
-exports._onError = function(err, res) {
+exports._toError = function(err, res) {
     if (err) return err;
     else return new Error('got ' + res.status + ' response');
 }

--- a/lib/static.js
+++ b/lib/static.js
@@ -146,7 +146,8 @@ exports.destroyAll = function(fn){
   this.request
     .del(url)
     .set(this._headers)
-    .end(function(res){
+    .end(function(err, res){
+      if (err) return fn(err, null, null);
       if (res.error) return fn(error(res), null, res);
       fn(null, [], res);
     });
@@ -166,6 +167,7 @@ exports.all = function(fn){
     .get(url)
     .set(this._headers)
     .end(function(res){
+      if (err) return fn(err, null, null);
       if (res.error) return fn(error(res), null, res);
       var col = new Collection;
       for (var i = 0, len = res.body.length; i < len; ++i) {
@@ -190,6 +192,7 @@ exports.get = function(id, fn){
     .get(url)
     .set(this._headers)
     .end(function(res){
+      if (err) return fn(err, null, null);
       if (res.error) return fn(error(res), null, res);
       var model = new self(res.body);
       fn(null, model, res);

--- a/lib/static.js
+++ b/lib/static.js
@@ -148,7 +148,7 @@ exports.destroyAll = function(fn){
     .set(this._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(error(err,res), null, res);
+        return fn(self._error(err,res), null, res);
       fn(null, [], res);
     });
 };
@@ -168,7 +168,7 @@ exports.all = function(fn){
     .set(this._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(error(err,res), null, res);
+        return fn(self._error(err,res), null, res);
       var col = new Collection;
       for (var i = 0, len = res.body.length; i < len; ++i) {
         col.push(new self(res.body[i]));
@@ -193,23 +193,21 @@ exports.get = function(id, fn){
     .set(this._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(error(err,res), null, res);
+        return fn(self._error(err,res), null, res);
       var model = new self(res.body);
       fn(null, model, res);
     });
 };
 
-/**
- * Response error helper.
- *
- * @param {Response} er
- * @return {Error}
- * @api private
- */
+exports.error = function(fn) {
+    if (fn) {
+        this._error = this.prototype._error = fn;
+    }
 
-function error(err, res) {
-  if (err) return err;
-  else return new Error('got ' + res.status + ' response');
+    return this;
 }
 
-exports.error = error;
+exports._error = function(err, res) {
+    if (err) return err;
+    else return new Error('got ' + res.status + ' response');
+}

--- a/lib/static.js
+++ b/lib/static.js
@@ -148,7 +148,7 @@ exports.destroyAll = function(fn){
     .set(this._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._error(err,res), null, res);
+        return fn(self._onError(err,res), null, res);
       fn(null, [], res);
     });
 };
@@ -168,7 +168,7 @@ exports.all = function(fn){
     .set(this._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._error(err,res), null, res);
+        return fn(self._onError(err,res), null, res);
       var col = new Collection;
       for (var i = 0, len = res.body.length; i < len; ++i) {
         col.push(new self(res.body[i]));
@@ -193,21 +193,36 @@ exports.get = function(id, fn){
     .set(this._headers)
     .end(function(err, res){
       if (err || res.error)
-        return fn(self._error(err,res), null, res);
+        return fn(self._onError(err,res), null, res);
       var model = new self(res.body);
       fn(null, model, res);
     });
 };
 
-exports.error = function(fn) {
+/**
+ * Register a custom error handler for the model class and its instances.
+ *
+ * @param {Function} fn
+ * @return {Object} self
+ * @api public
+ */
+exports.onError = function(fn) {
     if (fn) {
-        this._error = this.prototype._error = fn;
+        this._onError = this.prototype._onError = fn;
     }
 
     return this;
 }
 
-exports._error = function(err, res) {
+/**
+ * Standard error handler.
+ *
+ * @param {Error} err
+ * @param {Response} res
+ * @return {Error}
+ * @api private
+ */
+exports._onError = function(err, res) {
     if (err) return err;
     else return new Error('got ' + res.status + ' response');
 }

--- a/lib/static.js
+++ b/lib/static.js
@@ -3,13 +3,10 @@
  */
 
 try {
-  var Emitter = require('emitter');
-  var each = require('each');
+  var Collection = require('collection');
 } catch (e) {
-  var Emitter = require('component-emitter');
-  var each = require('component-each');
+  var Collection = require('component-collection');
 }
-var Collection = require('collection');
 var request = require('superagent');
 var noop = function(){};
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -147,8 +147,8 @@ exports.destroyAll = function(fn){
     .del(url)
     .set(this._headers)
     .end(function(err, res){
-      if (err) return fn(err, null, null);
-      if (res.error) return fn(error(res), null, res);
+      if (err || res.error)
+        return fn(error(err,res), null, res);
       fn(null, [], res);
     });
 };
@@ -166,9 +166,9 @@ exports.all = function(fn){
   this.request
     .get(url)
     .set(this._headers)
-    .end(function(res){
-      if (err) return fn(err, null, null);
-      if (res.error) return fn(error(res), null, res);
+    .end(function(err, res){
+      if (err || res.error)
+        return fn(error(err,res), null, res);
       var col = new Collection;
       for (var i = 0, len = res.body.length; i < len; ++i) {
         col.push(new self(res.body[i]));
@@ -191,9 +191,9 @@ exports.get = function(id, fn){
   this.request
     .get(url)
     .set(this._headers)
-    .end(function(res){
-      if (err) return fn(err, null, null);
-      if (res.error) return fn(error(res), null, res);
+    .end(function(err, res){
+      if (err || res.error)
+        return fn(error(err,res), null, res);
       var model = new self(res.body);
       fn(null, model, res);
     });
@@ -207,6 +207,9 @@ exports.get = function(id, fn){
  * @api private
  */
 
-function error(res) {
-  return new Error('got ' + res.status + ' response');
+function error(err, res) {
+  if (err) return err;
+  else return new Error('got ' + res.status + ' response');
 }
+
+export.error = error

--- a/lib/static.js
+++ b/lib/static.js
@@ -212,4 +212,4 @@ function error(err, res) {
   else return new Error('got ' + res.status + ' response');
 }
 
-exports.error = error
+exports.error = error;

--- a/package.json
+++ b/package.json
@@ -5,9 +5,16 @@
   "main": "lib/index.js",
   "dependencies": {
     "component-emitter": "~1.1.3",
-    "collection": "git://github.com/component/collection#0.0.2",
+    "component-collection": "~0.0.2",
     "component-each": "~0.2.5",
     "superagent": "~0.21.0"
+  },
+  "browser": {
+    "map": {
+      "emitter": "component-emitter",
+      "collection": "component-collection",
+      "each": "component-each"
+    }
   },
   "devDependencies": {
     "express": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -10,11 +10,9 @@
     "superagent": "~0.21.0"
   },
   "browser": {
-    "map": {
-      "emitter": "component-emitter",
-      "collection": "component-collection",
-      "each": "component-each"
-    }
+    "emitter": "component-emitter",
+    "collection": "component-collection",
+    "each": "component-each"
   },
   "devDependencies": {
     "express": "3.0.0"

--- a/test/model.js
+++ b/test/model.js
@@ -442,7 +442,7 @@ describe('Model#isValid()', function(){
   })
 })
 
-describe('Model#onError()', function() {
+describe('Model#toError()', function() {
   function getErrorHandler(static) {
     return function(err, res) {
       return {error: err, response: res, static: static};
@@ -456,7 +456,7 @@ describe('Model#onError()', function() {
 
     var car = new Car({color: 'blue'});
 
-    car.onError(getErrorHandler(false));
+    car.toError(getErrorHandler(false));
 
     car.save(function(err) {
       assert(null == err.error);
@@ -471,11 +471,11 @@ describe('Model#onError()', function() {
     var Car = model('Car')
       .attr('id')
       .attr('color')
-      .onError(getErrorHandler(true));
+      .toError(getErrorHandler(true));
 
     var car = new Car({color: 'red'});
 
-    car.onError(getErrorHandler(false));
+    car.toError(getErrorHandler(false));
 
     car.save(function(err) {
       assert(null == err.error);

--- a/test/model.js
+++ b/test/model.js
@@ -441,3 +441,63 @@ describe('Model#isValid()', function(){
     assert(0 == user.errors.length);
   })
 })
+
+describe('Model#onError()', function() {
+  function getErrorHandler(static) {
+    return function(err, res) {
+      return {error: err, response: res, static: static};
+    };
+  }
+
+  it('should be called on errors', function(done) {
+    var Car = model('Car')
+      .attr('id')
+      .attr('color');
+
+    var car = new Car({color: 'blue'});
+
+    car.onError(getErrorHandler(false));
+
+    car.save(function(err) {
+      assert(null == err.error);
+      assert(500 == err.response.status);
+      assert(false == err.static);
+
+      done();
+    });
+  });
+
+  it('should overwrite the static error handler', function(done) {
+    var Car = model('Car')
+      .attr('id')
+      .attr('color')
+      .onError(getErrorHandler(true));
+
+    var car = new Car({color: 'red'});
+
+    car.onError(getErrorHandler(false));
+
+    car.save(function(err) {
+      assert(null == err.error);
+      assert(500 == err.response.status);
+      assert(false == err.static);
+
+      done();
+    });
+  });
+
+  it('should use the default error handler if not called', function(done) {
+    var Car = model('Car')
+      .attr('id')
+      .attr('color');
+
+    var car = new Car({color: 'yellow'});
+
+    car.save(function(err) {
+      assert(err instanceof Error);
+      assert('got 500 response' == err.message);
+
+      done();
+    });
+  });
+});

--- a/test/server.js
+++ b/test/server.js
@@ -101,5 +101,21 @@ app.post('/users', function(req, res){
   res.send({ id: id });
 });
 
+app.get('/cars', function(req, res) {
+  setTimeout(function() {
+    res.send([]);
+  }, 500);
+});
+
+app.get('/cars/:id', function(req, res) {
+  setTimeout(function() {
+    res.send({id: req.params.id, color: 'silver'});
+  }, 500);
+});
+
+app.post('/cars', function(req, res) {
+  res.send(500);
+});
+
 app.listen(4000);
 console.log('test server listening on port 4000');

--- a/test/statics.js
+++ b/test/statics.js
@@ -69,11 +69,11 @@ describe('Model.route(string)', function(){
   })
 })
 
-describe('Model.onError()', function() {
+describe('Model.toError()', function() {
   var Car = model('Car')
     .attr('id')
     .attr('color')
-    .onError(function(err, res) {
+    .toError(function(err, res) {
       return {error: err, response: res};
     });
 
@@ -98,7 +98,6 @@ describe('Model.onError()', function() {
     Car.all(function(err, res) {
       assert(err.error instanceof Error);
       assert(-1 != err.error.message.indexOf('timeout'));
-
       done();
     });
   });
@@ -108,7 +107,6 @@ describe('Model.onError()', function() {
 
     car.save(function(err) {
       assert(500 == err.response.status);
-
       done();
     });
   });

--- a/test/statics.js
+++ b/test/statics.js
@@ -79,14 +79,23 @@ describe('Model.onError()', function() {
 
   var _request_get = Car.request.get;
 
-  Car.request.get = function(url) {
-    var req = _request_get(url);
-    req.timeout(30);
-    return req;
-  };
+  before( function(done) {
+    Car.request.get = function(url, data, fn) {
+      var req = _request_get(url, data, fn);
+      req.timeout(1);
+      return req;
+    };
+    done();
+  });
+
+  after( function(done) {
+    Car.request.get = _request_get;
+    done();
+  });
+
 
   it('should be called on errors', function(done) {
-    Car.all(function(err) {
+    Car.all(function(err, res) {
       assert(err.error instanceof Error);
       assert(-1 != err.error.message.indexOf('timeout'));
 

--- a/test/statics.js
+++ b/test/statics.js
@@ -94,7 +94,7 @@ describe('Model.toError()', function() {
   });
 
 
-  it('should be called on errors', function(done) {
+  it('should be called on errors (e.g. request timeout)', function(done) {
     Car.all(function(err, res) {
       assert(err.error instanceof Error);
       assert(-1 != err.error.message.indexOf('timeout'));


### PR DESCRIPTION
Hey, 

we have implemented a model plugin to handle errors. It's necessary for this, to get request errors (e.g. timeout/crossdomain) and return them on the "end" of a request.
Furthermore it's possible with this modification to manipulate the error info/data that is passed to the model callbacks (e.g. save( function(err){} )).

Perhaps this was something you meant with this issue (https://github.com/component/model/issues/8) also?
I'm excited about your feedback!

Frank. 
